### PR TITLE
Use Debian Stretch for the VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ def red(text); colorize(text, 31); end
 
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "torchbox/wagtail-jessie64"
-  config.vm.box_version = "~> 2.0"
+  config.vm.box = "torchbox/wagtail-stretch64"
+  config.vm.box_version = "~> 1.0"
 
   config.vm.network "forwarded_port", guest: 8000, host: 8000
 


### PR DESCRIPTION
Jessie backports do not longer resolve. It may cause issues when importing the database if Postgres database does not match the server's one, but I can't test it myself.