### PR TITLE
Reset form and add back button

### DIFF
--- a/mresponse/frontend/app/src/pages/moderate/index.js
+++ b/mresponse/frontend/app/src/pages/moderate/index.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = (dispatch, props) => ({
     'feedback_message': feedbackMessage
   })),
   submitModeration: cb => dispatch(submitModeration(cb)),
-  skipResponse: () => dispatch(skipResponse()),
+  skipResponse: cb => dispatch(skipResponse(cb)),
   submitApproval: cb => dispatch(submitApproval(cb))
 })
 

--- a/mresponse/frontend/app/src/pages/moderate/moderate.js
+++ b/mresponse/frontend/app/src/pages/moderate/moderate.js
@@ -203,13 +203,23 @@ export default class ModeratePage extends React.Component {
               </div>
             }
 
-            <div className='moderate-page-actions'>
-              <span
-                className='moderate-page-actions-skip'
-                onClick={() => {
-                  this.handleSkip()
-                }}>Skip</span>
-            </div>
+            {canSkipModeration && isModerating ? (
+              <div className='moderate-page-actions'>
+                <span
+                  className='moderate-page-actions-skip'
+                  onClick={() => {
+                    this.resetAll()
+                  }}>Back</span>
+              </div>
+            ) : (
+              <div className='moderate-page-actions'>
+                <span
+                  className='moderate-page-actions-skip'
+                  onClick={() => {
+                    this.handleSkip()
+                  }}>Skip</span>
+              </div>
+            )}
           </Fragment>
         ) : null}
       </div>

--- a/mresponse/frontend/app/src/pages/moderate/moderate.js
+++ b/mresponse/frontend/app/src/pages/moderate/moderate.js
@@ -249,7 +249,7 @@ export default class ModeratePage extends React.Component {
       } else {
         this.pushMessage(successMessage)
       }
-      this.resetData()
+      this.resetAll()
     })
   }
 
@@ -260,7 +260,7 @@ export default class ModeratePage extends React.Component {
       } else {
         this.pushMessage(message)
       }
-      this.resetData()
+      this.resetAll()
     })
   }
 
@@ -284,6 +284,22 @@ export default class ModeratePage extends React.Component {
     })
   }
 
+  resetAll = () => {
+    const {
+      profile: {
+        canSkipModeration
+      }
+    } = this.props
+
+    // Clear form data
+    this.resetData()
+
+    // Reset the form to it's hidden for trusted users
+    if (canSkipModeration) {
+      this.resetForm()
+    }
+  }
+
   resetData = () => this.setState(state => {
     return {
       ...state,
@@ -291,7 +307,8 @@ export default class ModeratePage extends React.Component {
         positive: null,
         relevant: null,
         personal: null
-      }
+      },
+      feedbackMessage: ''
     }
   })
 
@@ -304,17 +321,10 @@ export default class ModeratePage extends React.Component {
 
   handleSkip = () => {
     const {
-      skipResponse,
-      profile: {
-        canSkipModeration
-      }
+      skipResponse
     } = this.props
 
-    if (canSkipModeration) {
-      this.resetForm()
-    }
-
-    this.resetData()
+    this.resetAll()
 
     skipResponse()
   }

--- a/mresponse/frontend/app/src/pages/moderate/moderate.js
+++ b/mresponse/frontend/app/src/pages/moderate/moderate.js
@@ -336,6 +336,10 @@ export default class ModeratePage extends React.Component {
 
     this.resetAll()
 
-    skipResponse()
+    skipResponse((message, err) => {
+      if (err) {
+        this.pushMessage(message, true)
+      }
+    })
   }
 }

--- a/mresponse/frontend/app/src/pages/moderate/moderate.js
+++ b/mresponse/frontend/app/src/pages/moderate/moderate.js
@@ -334,11 +334,11 @@ export default class ModeratePage extends React.Component {
       skipResponse
     } = this.props
 
-    this.resetAll()
-
     skipResponse((message, err) => {
       if (err) {
         this.pushMessage(message, true)
+      } else {
+        this.resetAll()
       }
     })
   }

--- a/mresponse/frontend/app/src/redux/actions/moderate.js
+++ b/mresponse/frontend/app/src/redux/actions/moderate.js
@@ -66,11 +66,13 @@ export const skipResponse = (cb = () => null) =>
   connectApi(api =>
     async (dispatch, getState) => {
       const { moderate: { currentResponse } } = getState()
-      try {
-        await api.skipResponse(currentResponse.id)
-        return dispatch(fetchNextResponse())
-      } catch (e) {
-        console.error(e)
+      if (currentResponse) {
+        try {
+          await api.skipResponse(currentResponse.id)
+          return dispatch(fetchNextResponse())
+        } catch (e) {
+          cb(e.detail, true)
+        }
       }
     }
   )

--- a/mresponse/frontend/app/src/utils/api.js
+++ b/mresponse/frontend/app/src/utils/api.js
@@ -176,12 +176,19 @@ export default class Api {
   }
 
   async skipResponse (responseId) {
-    await this.fetch(`/api/response/skip/${responseId}/`, {
+    let response = await this.fetch(`/api/response/skip/${responseId}/`, {
       method: 'POST',
       headers: {
         'X-CSRFToken': Cookie.get('csrftoken')
       }
     })
+
+    if (!response.ok) {
+      const errorMessage = { detail: 'Unable to skip' }
+      throw errorMessage
+    }
+
+    return response
   }
 
   async uploadAvatar (file) {


### PR DESCRIPTION
- Reset form on submit or approval if is trusted user (so they see the "Approve" and "Moderate" buttons again. 
- Non-trusted users just see a cleared form.
- Add back button when trusted user is moderating. 
- Non trusted users can skip.