### PR TITLE
[256] Generate leaderboard for the previous week

### DIFF
--- a/mresponse/leaderboard/manager.py
+++ b/mresponse/leaderboard/manager.py
@@ -16,7 +16,8 @@ class LeaderboardManager(models.Manager):
         from mresponse.leaderboard.models import LeaderboardRecord
 
         today = timezone.now().date()
-        start = today - timezone.timedelta(days=today.weekday())
+        # Generate a leaderboard since Monday last week till Sunday that week.
+        start = today - timezone.timedelta(days=today.weekday(), weeks=1)
         end = start + timezone.timedelta(days=6)
         start = datetime.datetime.combine(start, datetime.time.min)
         end = datetime.datetime.combine(end, datetime.time.max)


### PR DESCRIPTION
#256

Currently the leaderboard is generated for the current week (it is generated on Monday, so there's no scores). It should be generated for the previous week to work properly.