### PR TITLE
[288] fix for level 1 moderator responses showing in moderation queue

### DIFF
--- a/mresponse/responses/query.py
+++ b/mresponse/responses/query.py
@@ -34,7 +34,9 @@ class ResponseQuerySet(models.QuerySet):
         return self.filter(approved=False)
 
     def moderator_queue(self):
-        return self.not_approved()
+        return self.not_approved().exclude(
+            author__user_permissions__codename='can_bypass_community_moderation'
+        )
 
     def no_moderations(self):
         return self.annotate_moderations_count().filter(moderations_count=0)

--- a/mresponse/responses/query.py
+++ b/mresponse/responses/query.py
@@ -34,9 +34,7 @@ class ResponseQuerySet(models.QuerySet):
         return self.filter(approved=False)
 
     def moderator_queue(self):
-        return self.not_approved().exclude(
-            author__user_permissions__codename='can_bypass_community_moderation'
-        )
+        return self.not_approved()
 
     def no_moderations(self):
         return self.annotate_moderations_count().filter(moderations_count=0)

--- a/mresponse/responses/tests.py
+++ b/mresponse/responses/tests.py
@@ -4,14 +4,15 @@ import json
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+import rest_framework.test
+from rest_framework import status
+
 import factory
 from mresponse.applications.models import Application
 from mresponse.reviews.models import Review
 from mresponse.users.tests import (BypassCommunityModerationUserFactory,
                                    BypassStaffModerationUserFactory,
                                    UserFactory)
-import rest_framework.test
-from rest_framework import status
 
 from .api.serializers import ResponseSerializer
 from .models import Response

--- a/mresponse/responses/tests.py
+++ b/mresponse/responses/tests.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -100,7 +99,7 @@ class TestGetResponseView(TestCase):
         response = self.client.get('/api/response/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
-            json.loads(response.content.decode())['detail'],
+            response.json()['detail'],
             'No responses available in the moderator queue.'
         )
 
@@ -109,7 +108,7 @@ class TestGetResponseView(TestCase):
         ResponseSerializerFactory()
         response = self.client.get('/api/response/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(json.loads(response.content.decode())['text'], 'test')
+        self.assertEqual(response.json()['text'], 'test')
 
     def test_returning_no_responses_to_moderate_for_approved_response(self):
         self.client.force_authenticate(user=UserFactory())
@@ -117,6 +116,6 @@ class TestGetResponseView(TestCase):
         response = self.client.get('/api/response/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
-            json.loads(response.content.decode())['detail'],
+            response.json()['detail'],
             'No responses available in the moderator queue.'
         )

--- a/mresponse/responses/tests.py
+++ b/mresponse/responses/tests.py
@@ -112,7 +112,7 @@ class TestGetResponseView(TestCase):
         self.assertEqual(json.loads(response.content.decode())['text'], 'test')
 
     def test_returning_no_responses_to_moderate_for_approved_response(self):
-        self.client.force_authenticate(user=BypassCommunityModerationUserFactory())
+        self.client.force_authenticate(user=UserFactory())
         ResponseSerializerFactory.create(author=BypassCommunityModerationUserFactory())
         response = self.client.get('/api/response/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/mresponse/users/tests.py
+++ b/mresponse/users/tests.py
@@ -10,13 +10,12 @@ User = get_user_model()
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
-        django_get_or_create = ("username",)
 
-    username = "jane"
+    username = factory.Sequence(lambda n: f'user{n}')
 
 
 class BypassCommunityModerationUserFactory(UserFactory):
-    username = "andrea"
+    username = factory.Sequence(lambda n: f'level_one_mod{n}')
 
     @factory.post_generation
     def user_permissions(self, create, extracted, **kwargs):


### PR DESCRIPTION
Fix for level 1 moderator responses showing in moderation queue https://github.com/mozilla/m-response/issues/288
