### PR TITLE
Fix "Profile photo is displayed only on mouse hover" issue #285

### DIFF
--- a/mresponse/frontend/app/src/components/avatar/avatar.scss
+++ b/mresponse/frontend/app/src/components/avatar/avatar.scss
@@ -9,6 +9,12 @@
     border-radius: 4px;
     width: 100%;
     height: 100%;
+    transition: 0.1s opacity;
+
+    &:hover {
+      opacity: 0.8;
+      cursor: pointer;
+    }
   }
 
   &-cover {

--- a/mresponse/frontend/app/src/components/avatar/index.js
+++ b/mresponse/frontend/app/src/components/avatar/index.js
@@ -7,8 +7,8 @@ import './avatar.scss'
 const Avatar = ({ src, coverIcon, className = '', editable, onClick, karma }) => {
   return (
     <div className={`avatar ${className}`}>
-      <img className="avatar-img" src={src} alt="" />
-      {editable || coverIcon ? (
+      <img className="avatar-img" src={src} alt="" onClick={onClick} />
+      {(editable || coverIcon) && !src ? (
         <div className="avatar-cover" onClick={onClick}>
           <img
             className="avatar-cover-icon"
@@ -32,7 +32,7 @@ const Avatar = ({ src, coverIcon, className = '', editable, onClick, karma }) =>
 }
 
 Avatar.propTypes = {
-  src: PropTypes.string.isRequired,
+  src: PropTypes.string,
   className: PropTypes.string,
   editable: PropTypes.bool,
   onClick: PropTypes.func,


### PR DESCRIPTION
Fixed some logic in the "Avatar" component as it was not checking if a profile image src URL was provided or not and therefore did not try to display that image. Also added pointer hover style to profile image element to indicate it is clickable.