### PR TITLE
add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+default_language_version:
+  python: python3.6
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: debug-statements
+  - repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black

--- a/README.rst
+++ b/README.rst
@@ -69,4 +69,12 @@ Data Retrieval from the Google Playstore
 To retrieve (download) reviews and publish (upload) responses on the Google Playstore, there is a small service.
 This service lives in its own repo: https://github.com/mozilla/m-response-api
 
+Committing changes
+------------------
 
+Set up `pre-commit <https://pre-commit.com/>`_ to automatically run flake8, black and other linters against your commmit:
+
+.. code:: sh
+
+   pip install pre-commit
+   pre-commit install

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ factory-boy==2.11.1
 ipdb==0.12.2
 flake8==3.8.3
 isort==4.3.21
+pre-commit~=2.5.1


### PR DESCRIPTION
flake8 and black already pass because of the travis job which checks them, so running `pre-commit run --all-files` doesn't cause any changes