### PR TITLE
quick fix: don't constrain height of reviews in moderate view

### DIFF
--- a/mresponse/frontend/app/src/components/moderate-card/moderate-card.scss
+++ b/mresponse/frontend/app/src/components/moderate-card/moderate-card.scss
@@ -62,7 +62,7 @@
         border-bottom: 1px solid $border-color;
 
         &-comment {
-            max-height: 90px;
+            // max-height: 90px;
             overflow: hidden;
             font-size: 14px;
             line-height: 24px;


### PR DESCRIPTION
Quick fix for https://github.com/mozilla/sumo-project/issues/522 and https://github.com/mozilla/m-response/issues/525

There's some very weird things going on with the near identical `ModerateCard` (which is used) and `ModerationCard` which isn't, but we can work that out after fixing the experience for contributors.