### PR TITLE
pin black version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
   include:
     - stage: lint
       name: lint back-end
-      install: pip install flake8 black
+      install: pip install flake8 black==19.10b0
       script:
         - flake8 mresponse
         - black --check mresponse


### PR DESCRIPTION
A new version of black caused https://travis-ci.org/github/mozilla/m-response/builds/724976763 to fail

Will open another PR to upgrade black to the latest version